### PR TITLE
Fix architecture validation message

### DIFF
--- a/scripts/build_debian_base_system.sh
+++ b/scripts/build_debian_base_system.sh
@@ -48,7 +48,7 @@ fi
 ARCH=$(dpkg --print-architecture)
 DISTRO=$(grep CODENAME /etc/os-release | cut -d= -f2)
 if [ "$ARCH" != "$CONFIGURED_ARCH" ] || [ "$DISTRO" != "$IMAGE_DISTRO" ]; then
-    "Not support to build different ARCH/DISTRO ${CONFIGURED_ARCH}:${IMAGE_DISTRO} in ${ARCH}:${DISTRO}."
+    echo "Not support to build different ARCH/DISTRO ${CONFIGURED_ARCH}:${IMAGE_DISTRO} in ${ARCH}:${DISTRO}."
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- properly print the architecture/distro mismatch error

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683f9ecc053483268fa94740e43025b1